### PR TITLE
Fix typo in multivector fixture

### DIFF
--- a/app/fixtures/multivector_fixture.json
+++ b/app/fixtures/multivector_fixture.json
@@ -282,7 +282,7 @@
         "asset_category": "energy_production",
         "energy_vector": "Electricity",
         "mvs_type": "source",
-        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap, renewable_asset, input_timeseries]",
+        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap,renewable_asset,input_timeseries]",
         "unit": "kWh"
     }
 },
@@ -294,7 +294,7 @@
         "asset_category": "energy_production",
         "energy_vector": "Electricity",
         "mvs_type": "source",
-        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap, renewable_asset, input_timeseries]",
+        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap,renewable_asset,input_timeseries]",
         "unit": "kWh"
     }
 },
@@ -306,7 +306,7 @@
         "asset_category": "energy_production",
         "energy_vector": "Gas",
         "mvs_type": "source",
-        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap, renewable_asset, input_timeseries]",
+        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap,renewable_asset,input_timeseries]",
         "unit": null
     }
 },
@@ -318,7 +318,7 @@
         "asset_category": "energy_production",
         "energy_vector": "Electricity",
         "mvs_type": "source",
-        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap, renewable_asset, input_timeseries]",
+        "asset_fields": "[name,age_installed,installed_capacity,capex_fix,capex_var,opex_fix,opex_var,lifetime,optimize_cap,renewable_asset,input_timeseries]",
         "unit": "kWh"
     }
 },


### PR DESCRIPTION
There is a space before the field names renewable_asset 
and input_timeseries in asset_type.asset_fields of some assets